### PR TITLE
Prevent code from running on server side (add support for Next.js SSR)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,22 @@
-window.requestIdleCallback =
-    window.requestIdleCallback ||
-    function(cb) {
-        var start = Date.now();
-        return setTimeout(function() {
-            cb({
-                didTimeout: false,
-                timeRemaining: function() {
-                    return Math.max(0, 50 - (Date.now() - start));
-                },
-            });
-        }, 1);
-    };
 
-window.cancelIdleCallback =
-    window.cancelIdleCallback ||
-    function(id) {
-        clearTimeout(id);
-    };
+if (typeof window !== 'undefined') {
+    window.requestIdleCallback =
+        window.requestIdleCallback ||
+        function(cb) {
+            var start = Date.now();
+            return setTimeout(function() {
+                cb({
+                    didTimeout: false,
+                    timeRemaining: function() {
+                        return Math.max(0, 50 - (Date.now() - start));
+                    },
+                });
+            }, 1);
+        };
+
+    window.cancelIdleCallback =
+        window.cancelIdleCallback ||
+        function(id) {
+            clearTimeout(id);
+        };
+}


### PR DESCRIPTION
When using this library with Next.js and their Server Side Generation, I ran into an issue where the rendering server will return an error:

`ReferenceError: window is not defined`

This PR fixes that issue and allows us to skip this code on the server, but continue running on the client side.